### PR TITLE
adding a watermark to compare versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 jupyterlab==4.4.1
 pyspark==4.0.0
-senzing==0.20.0
+senzing==0.2.20
 senzing_grpc==0.5.11
+watermark >= 2.5

--- a/spark_quickstart.ipynb
+++ b/spark_quickstart.ipynb
@@ -65,20 +65,87 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 1,
    "id": "02ac5b42",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:06:58.039623Z",
+     "iopub.status.busy": "2025-08-01T00:06:58.039448Z",
+     "iopub.status.idle": "2025-08-01T00:06:58.137965Z",
+     "shell.execute_reply": "2025-08-01T00:06:58.137598Z",
+     "shell.execute_reply.started": "2025-08-01T00:06:58.039603Z"
+    }
+   },
    "outputs": [],
    "source": [
-    "import grpc\n",
-    "from senzing import szengineflags, szerror\n",
-    "from senzing_grpc import SzAbstractFactoryGrpc\n",
-    "from pyspark.sql import SparkSession\n",
-    "from pyspark.sql.functions import col, collect_list, array, array_except\n",
     "import json\n",
     "import os\n",
     "import requests\n",
-    "import shutil"
+    "import shutil\n",
+    "\n",
+    "from pyspark.sql import SparkSession\n",
+    "from pyspark.sql.functions import col, collect_list, array, array_except\n",
+    "from senzing import szengineflags, szerror\n",
+    "from senzing_grpc import SzAbstractFactoryGrpc\n",
+    "import grpc\n",
+    "import watermark"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2642ce0-4130-4ad7-bb71-f83f9a3dd0c5",
+   "metadata": {},
+   "source": [
+    "A watermark shows the versions of platforms and Python library dependencies being used:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b87100a0-5265-471b-99c1-9aff60f2af02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:06:58.138458Z",
+     "iopub.status.busy": "2025-08-01T00:06:58.138348Z",
+     "iopub.status.idle": "2025-08-01T00:06:58.149708Z",
+     "shell.execute_reply": "2025-08-01T00:06:58.149426Z",
+     "shell.execute_reply.started": "2025-08-01T00:06:58.138450Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Last updated: 2025-07-31T17:06:58.139299-07:00\n",
+      "\n",
+      "Python implementation: CPython\n",
+      "Python version       : 3.11.9\n",
+      "IPython version      : 9.4.0\n",
+      "\n",
+      "Compiler    : Clang 13.0.0 (clang-1300.0.29.30)\n",
+      "OS          : Darwin\n",
+      "Release     : 24.5.0\n",
+      "Machine     : arm64\n",
+      "Processor   : arm\n",
+      "CPU cores   : 14\n",
+      "Architecture: 64bit\n",
+      "\n",
+      "pyspark     : 4.0.0\n",
+      "watermark   : 2.5.0\n",
+      "senzing     : 0.2.20\n",
+      "senzing_grpc: 0.5.11\n",
+      "grpc        : 1.73.1\n",
+      "json        : 2.0.9\n",
+      "requests    : 2.32.4\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext watermark\n",
+    "%watermark\n",
+    "%watermark --iversions"
    ]
   },
   {
@@ -101,9 +168,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "9ec59153",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:06:58.151207Z",
+     "iopub.status.busy": "2025-08-01T00:06:58.151067Z",
+     "iopub.status.idle": "2025-08-01T00:06:58.153659Z",
+     "shell.execute_reply": "2025-08-01T00:06:58.153117Z",
+     "shell.execute_reply.started": "2025-08-01T00:06:58.151192Z"
+    }
+   },
    "outputs": [],
    "source": [
     "data_path = \"./data/\"\n",
@@ -117,9 +192,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "ccf680c3",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:06:58.154324Z",
+     "iopub.status.busy": "2025-08-01T00:06:58.154231Z",
+     "iopub.status.idle": "2025-08-01T00:06:58.156805Z",
+     "shell.execute_reply": "2025-08-01T00:06:58.156583Z",
+     "shell.execute_reply.started": "2025-08-01T00:06:58.154316Z"
+    }
+   },
    "outputs": [],
    "source": [
     "os.makedirs(data_path, exist_ok=True)\n",
@@ -152,9 +235,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "81a8d554",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:06:58.157298Z",
+     "iopub.status.busy": "2025-08-01T00:06:58.157176Z",
+     "iopub.status.idle": "2025-08-01T00:07:00.297366Z",
+     "shell.execute_reply": "2025-08-01T00:07:00.297061Z",
+     "shell.execute_reply.started": "2025-08-01T00:06:58.157287Z"
+    }
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -162,12 +253,9 @@
      "text": [
       "WARNING: Using incubator modules: jdk.incubator.vector\n",
       "Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties\n",
-      "25/07/21 16:35:12 WARN Utils: Your hostname, Catherines-MacBook-Air-2.local, resolves to a loopback address: 127.0.0.1; using 192.168.0.4 instead (on interface en0)\n",
-      "25/07/21 16:35:12 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n",
-      "Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties\n",
       "Setting default log level to \"WARN\".\n",
       "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n",
-      "25/07/21 16:35:13 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
+      "25/07/31 17:06:59 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n"
      ]
     }
    ],
@@ -187,35 +275,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "81cac0db",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "                                                                                \r"
-     ]
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:00.298148Z",
+     "iopub.status.busy": "2025-08-01T00:07:00.298009Z",
+     "iopub.status.idle": "2025-08-01T00:07:01.502692Z",
+     "shell.execute_reply": "2025-08-01T00:07:01.502260Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:00.298133Z"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
     "customers = spark.read.json(\"data/customers.json\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "83d797f3",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "25/07/21 16:35:18 WARN SparkStringUtils: Truncated the string representation of a plan since it was too large. This behavior can be adjusted by setting 'spark.sql.debug.maxToStringFields'.\n"
-     ]
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:01.503394Z",
+     "iopub.status.busy": "2025-08-01T00:07:01.503294Z",
+     "iopub.status.idle": "2025-08-01T00:07:01.761173Z",
+     "shell.execute_reply": "2025-08-01T00:07:01.760919Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:01.503386Z"
     },
+    "scrolled": true
+   },
+   "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
@@ -235,6 +325,13 @@
       "|         NULL|        NULL|     NULL| 1304 Poppy Hills Dr|           43004|      NULL|     HOME|   100|    NULL|  CUSTOMERS|1/11/18|     10/27/76|                  NULL|                 NULL|              NULL|  NULL|               NULL|              NULL|            NULL|            NULL|           NULL|        NULL|      NULL|             Marie|             NULL|            Kusha|               NULL|            NULL|     1016|     PERSON|              NULL|       NULL|    Active|\n",
       "+-------------+------------+---------+--------------------+----------------+----------+---------+------+--------+-----------+-------+-------------+----------------------+---------------------+------------------+------+-------------------+------------------+----------------+----------------+---------------+------------+----------+------------------+-----------------+-----------------+-------------------+----------------+---------+-----------+------------------+-----------+----------+\n",
       "only showing top 10 rows\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "25/07/31 17:07:01 WARN SparkStringUtils: Truncated the string representation of a plan since it was too large. This behavior can be adjusted by setting 'spark.sql.debug.maxToStringFields'.\n"
      ]
     }
    ],
@@ -260,9 +357,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "b14d7580",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:01.761689Z",
+     "iopub.status.busy": "2025-08-01T00:07:01.761615Z",
+     "iopub.status.idle": "2025-08-01T00:07:01.801244Z",
+     "shell.execute_reply": "2025-08-01T00:07:01.800961Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:01.761681Z"
+    }
+   },
    "outputs": [],
    "source": [
     "reference = spark.read.json(\"data/reference.json\")"
@@ -270,9 +375,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "ee108709",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:01.801957Z",
+     "iopub.status.busy": "2025-08-01T00:07:01.801780Z",
+     "iopub.status.idle": "2025-08-01T00:07:01.890797Z",
+     "shell.execute_reply": "2025-08-01T00:07:01.890437Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:01.801943Z"
+    },
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -302,9 +416,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "4595c698",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:01.891375Z",
+     "iopub.status.busy": "2025-08-01T00:07:01.891293Z",
+     "iopub.status.idle": "2025-08-01T00:07:01.924604Z",
+     "shell.execute_reply": "2025-08-01T00:07:01.924290Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:01.891364Z"
+    }
+   },
    "outputs": [],
    "source": [
     "watchlist = spark.read.json(\"data/watchlist.json\")"
@@ -312,9 +434,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "f8b62c28",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:01.925114Z",
+     "iopub.status.busy": "2025-08-01T00:07:01.925034Z",
+     "iopub.status.idle": "2025-08-01T00:07:01.992419Z",
+     "shell.execute_reply": "2025-08-01T00:07:01.992159Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:01.925107Z"
+    },
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -376,9 +507,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "f446a55e",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:01.994766Z",
+     "iopub.status.busy": "2025-08-01T00:07:01.994660Z",
+     "iopub.status.idle": "2025-08-01T00:07:01.998563Z",
+     "shell.execute_reply": "2025-08-01T00:07:01.998264Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:01.994758Z"
+    }
+   },
    "outputs": [],
    "source": [
     "grpc_channel = grpc.insecure_channel(\"localhost:8261\")\n",
@@ -395,9 +534,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "1ec6a775",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:01.999073Z",
+     "iopub.status.busy": "2025-08-01T00:07:01.998971Z",
+     "iopub.status.idle": "2025-08-01T00:07:02.003403Z",
+     "shell.execute_reply": "2025-08-01T00:07:02.003063Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:01.999064Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -436,9 +583,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "96d8e7a9",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:02.003943Z",
+     "iopub.status.busy": "2025-08-01T00:07:02.003821Z",
+     "iopub.status.idle": "2025-08-01T00:07:02.005929Z",
+     "shell.execute_reply": "2025-08-01T00:07:02.005506Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:02.003936Z"
+    }
+   },
    "outputs": [],
    "source": [
     "sz_configmanager = sz_abstract_factory.create_configmanager()\n",
@@ -456,9 +611,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "7324336c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:02.006531Z",
+     "iopub.status.busy": "2025-08-01T00:07:02.006426Z",
+     "iopub.status.idle": "2025-08-01T00:07:02.012665Z",
+     "shell.execute_reply": "2025-08-01T00:07:02.012446Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:02.006524Z"
+    }
+   },
    "outputs": [],
    "source": [
     "config_id = sz_configmanager.get_default_config_id()\n",
@@ -467,9 +630,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "c0a23e02",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:02.013151Z",
+     "iopub.status.busy": "2025-08-01T00:07:02.013043Z",
+     "iopub.status.idle": "2025-08-01T00:07:02.030604Z",
+     "shell.execute_reply": "2025-08-01T00:07:02.030328Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:02.013144Z"
+    }
+   },
    "outputs": [],
    "source": [
     "for data_source in [\"CUSTOMERS\", \"REFERENCE\", \"WATCHLIST\"]:\n",
@@ -486,9 +657,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "1e23073d",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:02.031045Z",
+     "iopub.status.busy": "2025-08-01T00:07:02.030980Z",
+     "iopub.status.idle": "2025-08-01T00:07:02.040550Z",
+     "shell.execute_reply": "2025-08-01T00:07:02.040197Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:02.031038Z"
+    }
+   },
    "outputs": [],
    "source": [
     "new_json_config = sz_config.export()\n",
@@ -506,9 +685,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "b54b6bd3",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:02.041116Z",
+     "iopub.status.busy": "2025-08-01T00:07:02.041032Z",
+     "iopub.status.idle": "2025-08-01T00:07:02.350184Z",
+     "shell.execute_reply": "2025-08-01T00:07:02.349235Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:02.041109Z"
+    }
+   },
    "outputs": [],
    "source": [
     "sz_abstract_factory.reinitialize(new_config_id)"
@@ -562,9 +749,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "0b06691a",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:02.351240Z",
+     "iopub.status.busy": "2025-08-01T00:07:02.351024Z",
+     "iopub.status.idle": "2025-08-01T00:07:02.354857Z",
+     "shell.execute_reply": "2025-08-01T00:07:02.354247Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:02.351219Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def get_affected_entities(info_string):\n",
@@ -575,9 +770,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "8d6836c4",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:02.355855Z",
+     "iopub.status.busy": "2025-08-01T00:07:02.355513Z",
+     "iopub.status.idle": "2025-08-01T00:07:09.009538Z",
+     "shell.execute_reply": "2025-08-01T00:07:09.009108Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:02.355827Z"
+    },
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -775,9 +979,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "e7f8f4b9",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:09.010047Z",
+     "iopub.status.busy": "2025-08-01T00:07:09.009961Z",
+     "iopub.status.idle": "2025-08-01T00:07:09.012057Z",
+     "shell.execute_reply": "2025-08-01T00:07:09.011778Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:09.010039Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -821,9 +1033,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "d95d8aec",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:09.012402Z",
+     "iopub.status.busy": "2025-08-01T00:07:09.012337Z",
+     "iopub.status.idle": "2025-08-01T00:07:09.034729Z",
+     "shell.execute_reply": "2025-08-01T00:07:09.034257Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:09.012396Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -865,9 +1085,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "f1ca0965",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:09.035484Z",
+     "iopub.status.busy": "2025-08-01T00:07:09.035339Z",
+     "iopub.status.idle": "2025-08-01T00:07:09.042812Z",
+     "shell.execute_reply": "2025-08-01T00:07:09.042408Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:09.035469Z"
+    },
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1271,9 +1500,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "id": "e6ea16ef",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:09.043653Z",
+     "iopub.status.busy": "2025-08-01T00:07:09.043489Z",
+     "iopub.status.idle": "2025-08-01T00:07:09.048311Z",
+     "shell.execute_reply": "2025-08-01T00:07:09.047694Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:09.043638Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def get_records_for_entity(entity_id):\n",
@@ -1285,9 +1522,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 25,
    "id": "5f611230",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:09.049058Z",
+     "iopub.status.busy": "2025-08-01T00:07:09.048920Z",
+     "iopub.status.idle": "2025-08-01T00:07:09.113072Z",
+     "shell.execute_reply": "2025-08-01T00:07:09.112575Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:09.049046Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# build entity to record map\n",
@@ -1316,9 +1561,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 26,
    "id": "380318ec",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:09.113873Z",
+     "iopub.status.busy": "2025-08-01T00:07:09.113720Z",
+     "iopub.status.idle": "2025-08-01T00:07:09.121277Z",
+     "shell.execute_reply": "2025-08-01T00:07:09.120862Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:09.113859Z"
+    },
+    "scrolled": true
+   },
    "outputs": [
     {
      "data": {
@@ -1417,7 +1671,7 @@
        " 158: ['2082']}"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1452,9 +1706,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 27,
    "id": "b5107600",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:09.122011Z",
+     "iopub.status.busy": "2025-08-01T00:07:09.121786Z",
+     "iopub.status.idle": "2025-08-01T00:07:09.146399Z",
+     "shell.execute_reply": "2025-08-01T00:07:09.146106Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:09.122001Z"
+    }
+   },
    "outputs": [],
    "source": [
     "entity_record_data = [\n",
@@ -1475,9 +1737,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 28,
    "id": "70e19374",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:09.146978Z",
+     "iopub.status.busy": "2025-08-01T00:07:09.146911Z",
+     "iopub.status.idle": "2025-08-01T00:07:09.171961Z",
+     "shell.execute_reply": "2025-08-01T00:07:09.171683Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:09.146972Z"
+    }
+   },
    "outputs": [],
    "source": [
     "entity_grouped = entity_record_df.groupBy(\"ENTITY_ID\").agg(\n",
@@ -1495,9 +1765,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 29,
    "id": "b4337e64",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:09.172471Z",
+     "iopub.status.busy": "2025-08-01T00:07:09.172388Z",
+     "iopub.status.idle": "2025-08-01T00:07:09.193664Z",
+     "shell.execute_reply": "2025-08-01T00:07:09.193386Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:09.172463Z"
+    }
+   },
    "outputs": [],
    "source": [
     "customers = customers.join(entity_record_df, \"RECORD_ID\", \"left\")\n",
@@ -1514,9 +1792,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 30,
    "id": "a7a4c20c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:09.194086Z",
+     "iopub.status.busy": "2025-08-01T00:07:09.194006Z",
+     "iopub.status.idle": "2025-08-01T00:07:09.219454Z",
+     "shell.execute_reply": "2025-08-01T00:07:09.219090Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:09.194080Z"
+    }
+   },
    "outputs": [],
    "source": [
     "customers = customers.withColumn(\n",
@@ -1527,15 +1813,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 31,
    "id": "a38b596f",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:09.219927Z",
+     "iopub.status.busy": "2025-08-01T00:07:09.219857Z",
+     "iopub.status.idle": "2025-08-01T00:07:10.186893Z",
+     "shell.execute_reply": "2025-08-01T00:07:10.186591Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:09.219920Z"
+    },
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "                                                                                \r"
+      "                                                                                "
      ]
     },
     {
@@ -1581,9 +1876,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 32,
    "id": "d964ebb1",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:10.187511Z",
+     "iopub.status.busy": "2025-08-01T00:07:10.187380Z",
+     "iopub.status.idle": "2025-08-01T00:07:10.535372Z",
+     "shell.execute_reply": "2025-08-01T00:07:10.535083Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:10.187495Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1592,16 +1895,16 @@
       "+---------+---------+------------------------+\n",
       "|RECORD_ID|ENTITY_ID|RELATED_RECORD_IDS      |\n",
       "+---------+---------+------------------------+\n",
-      "|1004     |1        |[1002, 1001, 1003]      |\n",
+      "|1009     |6        |[1010, 1011, 1012, 1014]|\n",
       "|1010     |6        |[1009, 1011, 1012, 1014]|\n",
+      "|1011     |6        |[1009, 1010, 1012, 1014]|\n",
+      "|1015     |9        |[1016, 1017, 1018]      |\n",
       "|1016     |9        |[1015, 1017, 1018]      |\n",
       "|1017     |9        |[1015, 1016, 1018]      |\n",
       "|1005     |5        |[1006]                  |\n",
-      "|1011     |6        |[1009, 1010, 1012, 1014]|\n",
-      "|1015     |9        |[1016, 1017, 1018]      |\n",
-      "|1009     |6        |[1010, 1011, 1012, 1014]|\n",
-      "|1003     |1        |[1002, 1001, 1004]      |\n",
+      "|1001     |1        |[1002, 1003, 1004]      |\n",
       "|1002     |1        |[1001, 1003, 1004]      |\n",
+      "|1003     |1        |[1002, 1001, 1004]      |\n",
       "+---------+---------+------------------------+\n",
       "only showing top 10 rows\n"
      ]
@@ -1613,9 +1916,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 33,
    "id": "7e6fd08f",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-08-01T00:07:10.535811Z",
+     "iopub.status.busy": "2025-08-01T00:07:10.535740Z",
+     "iopub.status.idle": "2025-08-01T00:07:11.514887Z",
+     "shell.execute_reply": "2025-08-01T00:07:11.513790Z",
+     "shell.execute_reply.started": "2025-08-01T00:07:10.535804Z"
+    }
+   },
    "outputs": [],
    "source": [
     "spark.stop()"
@@ -1636,7 +1947,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "senzing-databricks",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1650,7 +1961,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.0"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
There was a dependency `senzing==0.20.0` in the `requirements.txt` file,
although I believe this should be `senzing==0.2.20` instead?

Also added the `watermark` library so that we can track within the Jupyter notebooks which versions of platforms and libraries are being used.